### PR TITLE
feat: create yarn command to link or unlink payload tools to local project

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "typecheck": "npm run typecheck --workspaces --if-present",
     "test:coverage": "npm run test:coverage --workspaces --if-present",
     "testbed": "npm run build && npm run dev -w packages/testbed",
+    "packages:link": "ts-node scripts/link.ts",
+    "packages:unlink": "ts-node scripts/unlink.ts",
     "set-payload-version": "./scripts/set-payload-version.sh"
   },
   "workspaces": [

--- a/scripts/link.ts
+++ b/scripts/link.ts
@@ -1,0 +1,69 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { PackageJson } from './types';
+import { DEFAULT_LOCAL_LINKS, parseJSONFile } from './utils';
+
+const cwd = process.cwd();
+const root = path.join(cwd, '..');
+const serviceDirNames = process.argv.slice(2);
+const yarnLinkPath = path.join(os.homedir(), '.config', 'yarn', 'link');
+
+function linkPackage(workspacePath: string): void {
+  const { name: packageName } = parseJSONFile<PackageJson>(path.join(cwd, workspacePath, `package.json`)) ?? {};
+  if (!packageName) {
+    console.error(`Couldn't parse package.json! in ${workspacePath}`);
+    process.exit(1);
+  }
+
+  if (!DEFAULT_LOCAL_LINKS.includes(packageName)) {
+    return;
+  }
+
+  // Create a symbolic link of the SDK package with yarn if it does not yet exist
+  console.log(`Checking if a symbolic link for ${packageName} is registered with yarn.`);
+  if (!fs.existsSync(path.join(yarnLinkPath, packageName))) {
+    console.log(`Creating yarn symbolic link for ${packageName}.`);
+    try {
+      execSync(`cd ${workspacePath} && yarn link`, { stdio: 'inherit' });
+    } catch {
+      console.error('Symbolic link creation failed!');
+      process.exit(1);
+    }
+  } else {
+    console.log(`Symbolic link for ${packageName} already exists.`);
+  }
+
+  if (serviceDirNames.length !== 0) {
+    console.log(`Linking local SDK package to the following services: ${serviceDirNames.join(', ')}.`);
+    // iterate over the service directories specified in the command line arguments
+    for (const dirName of serviceDirNames) {
+      const servicePath = path.join(root, dirName);
+      console.log({ servicePath });
+      // link the local folder of the SDK package as the installed dependency of this service
+      if (fs.existsSync(servicePath)) {
+        console.log(`Linking ${packageName} to ${dirName}.`);
+        try {
+          execSync(`yarn link ${packageName}`, { cwd: servicePath, stdio: 'inherit' });
+        } catch {
+          console.error(`Package linking failed for ${dirName}.`);
+          continue;
+        }
+      } else {
+        console.warn(`Couldn't find ${dirName}, package linking skipped.`);
+      }
+    }
+  } else {
+    console.log(
+      'No services specified for linking. If you want to link some, list their directory names as command line arguments for this script.',
+    );
+  }
+}
+
+void (async () => {
+  const { workspaces } = parseJSONFile<PackageJson>(path.join(cwd, `package.json`)) ?? { workspaces: [] };
+  for (const workspace of workspaces) {
+    linkPackage(workspace);
+  }
+})();

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -1,0 +1,6 @@
+export interface PackageJson {
+  name: string;
+  dependencies: Record<string, string>;
+  peerDependencies: Record<string, string>;
+  workspaces: string[];
+}

--- a/scripts/unlink.ts
+++ b/scripts/unlink.ts
@@ -1,0 +1,148 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { PackageJson } from './types';
+import { DEFAULT_LOCAL_LINKS, parseJSONFile } from './utils';
+
+const cwd = process.cwd();
+const root = path.join(cwd, '..');
+const serviceDirNames = process.argv.slice(2);
+const yarnLinkPath = path.join(os.homedir(), '.config', 'yarn', 'link');
+
+function unlinkPackage(workspacePath: string): void {
+  const { name: packageName } = parseJSONFile<PackageJson>(path.join(cwd, workspacePath, `package.json`)) ?? {};
+
+  if (!packageName) {
+    console.error(`Couldn't parse package.json! in ${workspacePath}`);
+    process.exit(1);
+  }
+
+  if (!DEFAULT_LOCAL_LINKS.includes(packageName)) {
+    return;
+  }
+
+  if (serviceDirNames.length === 0) {
+    // delete the symbolic link of the package with yarn if it exists
+    if (fs.existsSync(path.join(yarnLinkPath, packageName))) {
+      console.log(`Deleting yarn symbolic link of ${packageName}.`);
+      try {
+        execSync(`cd ${workspacePath} && yarn unlink`, { stdio: 'inherit' });
+      } catch {
+        console.error('Symbolic link deletion failed!');
+        process.exit(1);
+      }
+    } else {
+      console.log(`Symbolic link for ${packageName} does not exist.`);
+    }
+
+    // if a service repo has a (now broken) link to the local package, force reinstall its dependencies as the `yarn unlink` documentation says
+    // there is no real best solution for this issue using yarn v1, using ideas from https://github.com/yarnpkg/yarn/issues/1722 to find links to this specific package and reinstall it
+
+    let rootFileNames: string[];
+
+    console.log('Collecting local service directories to check.');
+    try {
+      rootFileNames = fs.readdirSync(root);
+    } catch {
+      console.error("Couldn't collect local service directory names!");
+      process.exit(1);
+    }
+
+    console.log('Checking service directories and reinstalling remote package if needed.');
+    // iterating over files in the directory that contains repositories and checking the service directories for symlinks to the local package
+    for (const fileName of rootFileNames) {
+      const filePath = path.join(root, fileName);
+      let fileStat: fs.Stats;
+
+      try {
+        fileStat = fs.lstatSync(filePath);
+      } catch {
+        console.error(`Couldn't get file stats for ${filePath}!`);
+        continue;
+      }
+
+      if (fileStat.isDirectory()) {
+        const dirName = fileName;
+        const servicePath = filePath;
+        const packagePath = path.join(servicePath, 'node_modules', packageName);
+        let wasLinked: boolean;
+
+        console.log(`Checking ${dirName}.`);
+        try {
+          wasLinked = fs.lstatSync(packagePath).isSymbolicLink();
+        } catch {
+          // there is not even a broken symlink at the specified path
+          wasLinked = false;
+        }
+
+        if (wasLinked) {
+          console.log(`${packageName} was linked to ${dirName}, reinstalling remote package.`);
+          try {
+            execSync('yarn install --force', {
+              cwd: servicePath,
+              stdio: 'inherit',
+            });
+          } catch {
+            console.error(`Dependency installation failed for ${dirName}!`);
+            continue;
+          }
+        } else {
+          console.log(`${packageName} was not linked to ${dirName}.`);
+        }
+      }
+    }
+  } else {
+    console.log(`Unlinking local package from the following services: ${serviceDirNames.join(', ')}.`);
+    // iterate over the specified service repos and unlink the local package from them and reinstall their dependencies
+    for (const dirName of serviceDirNames) {
+      const servicePath = path.join(root, dirName);
+
+      if (fs.existsSync(servicePath)) {
+        const packagePath = path.join(servicePath, 'node_modules', packageName);
+        let isLinked: boolean;
+
+        console.log(`Checking if ${packageName} is linked to ${dirName}.`);
+        try {
+          isLinked = fs.existsSync(packagePath) && fs.lstatSync(packagePath).isSymbolicLink();
+        } catch {
+          console.error(`Link check failed for ${dirName}!`);
+          continue;
+        }
+
+        if (isLinked) {
+          console.log(`${packageName} is linked to ${dirName}, unlinking local package.`);
+          try {
+            execSync(`yarn unlink ${packageName}`, {
+              cwd: servicePath,
+              stdio: 'inherit',
+            });
+          } catch {
+            console.error(`Unlinking failed for ${dirName}!`);
+            continue;
+          }
+
+          console.log('Reinstalling remote package.');
+          try {
+            execSync('yarn install --force', {
+              cwd: servicePath,
+              stdio: 'inherit',
+            });
+          } catch {
+            console.error(`Dependency installation failed for ${dirName}!`);
+            continue;
+          }
+        }
+      } else {
+        console.warn(`Couldn't find ${dirName}, package unlinking skipped.`);
+      }
+    }
+  }
+}
+
+void (async () => {
+  const { workspaces } = parseJSONFile<PackageJson>(path.join(cwd, `package.json`)) ?? { workspaces: [] };
+  for (const workspace of workspaces) {
+    unlinkPackage(workspace);
+  }
+})();

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,0 +1,10 @@
+import * as fs from 'fs';
+
+export const DEFAULT_LOCAL_LINKS = ['payload-swagger', 'payload-openapi'];
+export function parseJSONFile<T>(path: string): T | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(path, 'utf8')) as T;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION


Fixes #create yarn command to link or unlink payload tools to local project

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
