### PR TITLE
feat(HPP-946): bumps payload and unset additional properties in schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16335,7 +16335,7 @@
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
         "get-tsconfig": "^4.5.0",
-        "payload": "^2.2.0"
+        "payload": "^2.4.0"
       },
       "bin": {
         "create-payload-api-docs": "bin/cli.js"
@@ -16343,6 +16343,17 @@
       "devDependencies": {
         "@types/command-line-args": "^5.2.0",
         "@types/command-line-usage": "^5.0.2"
+      }
+    },
+    "packages/create-api-docs/node_modules/@livit/portal.cms.payload-openapi": {
+      "version": "0.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@livit/portal.cms.payload-openapi/0.0.1/9075c4d553927a0a25888ee7cc71c33adb669009",
+      "integrity": "sha512-CqF314v8F4qn35zJzdjhgzfZNKzo/oh2k0+iDT8obtwzuoC+egYBR5w65u+sVTDJ8xzJFWbfKdL+9ZpuaFIrsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@openapi-contrib/json-schema-to-openapi-schema": "^2.2.5",
+        "lodash.mergewith": "^4.6.2",
+        "ts-powertools": "0.0.5"
       }
     },
     "packages/create-api-docs/node_modules/body-parser": {
@@ -16471,9 +16482,9 @@
       }
     },
     "packages/create-api-docs/node_modules/payload": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/payload/-/payload-2.2.2.tgz",
-      "integrity": "sha512-Bc8adkLKYet28ywAydKLALbw3HFL/qeqj4oCY+z1Bp179XpCMGyNhhW12fdozi9UKySNV4BkiULc1U+aMOL8eQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/payload/-/payload-2.5.0.tgz",
+      "integrity": "sha512-OQRpRsQJhrQZ9EKsTCpcL9a9rxpNIEj2CvCDn8QEozx+rD0cUZmOmwIeK5HilXVqvjO9v70kllO5Jtr8QNMjSA==",
       "dependencies": {
         "@date-io/date-fns": "2.16.0",
         "@dnd-kit/core": "6.0.8",
@@ -16751,6 +16762,11 @@
         "streamx": "^2.15.0"
       }
     },
+    "packages/create-api-docs/node_modules/ts-powertools": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ts-powertools/-/ts-powertools-0.0.5.tgz",
+      "integrity": "sha512-YQyW3AnjkUyJgY5cuOBXu73FnZFNKrWpU0Nc/1R7bnzNPA159LaW9DJCYpao6oQQoCTLrV4rSWRzPPNr5AAjlg=="
+    },
     "packages/create-api-docs/node_modules/use-context-selector": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.4.1.tgz",
@@ -16778,7 +16794,7 @@
     },
     "packages/openapi": {
       "name": "@livit/portal.cms.payload-openapi",
-      "version": "0.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@openapi-contrib/json-schema-to-openapi-schema": "^2.2.5",
@@ -16804,7 +16820,7 @@
         "jest": "^29.5.0",
         "lint-staged": "^13.1.2",
         "openapi-types": "^12.1.0",
-        "payload": "^2.2.0",
+        "payload": "^2.4.0",
         "prettier": "^2.8.4",
         "rimraf": "^4.4.0",
         "ts-jest": "^29.1.0",
@@ -17036,9 +17052,9 @@
       }
     },
     "packages/openapi/node_modules/payload": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/payload/-/payload-2.2.2.tgz",
-      "integrity": "sha512-Bc8adkLKYet28ywAydKLALbw3HFL/qeqj4oCY+z1Bp179XpCMGyNhhW12fdozi9UKySNV4BkiULc1U+aMOL8eQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/payload/-/payload-2.5.0.tgz",
+      "integrity": "sha512-OQRpRsQJhrQZ9EKsTCpcL9a9rxpNIEj2CvCDn8QEozx+rD0cUZmOmwIeK5HilXVqvjO9v70kllO5Jtr8QNMjSA==",
       "dev": true,
       "dependencies": {
         "@date-io/date-fns": "2.16.0",
@@ -17909,10 +17925,10 @@
     },
     "packages/swagger": {
       "name": "@livit/portal.cms.payload-swagger",
-      "version": "0.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@livit/portal.cms.payload-openapi": "^0.0.1",
+        "@livit/portal.cms.payload-openapi": "^1.0.2",
         "swagger-ui-express": "^4.6.2"
       },
       "devDependencies": {
@@ -17932,7 +17948,7 @@
         "husky": "^8.0.3",
         "jest": "^29.5.0",
         "lint-staged": "^13.1.2",
-        "payload": "^2.2.0",
+        "payload": "^2.4.0",
         "prettier": "^2.8.4",
         "rimraf": "^4.4.0",
         "ts-jest": "^29.1.0",
@@ -18080,9 +18096,9 @@
       }
     },
     "packages/swagger/node_modules/payload": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/payload/-/payload-2.2.2.tgz",
-      "integrity": "sha512-Bc8adkLKYet28ywAydKLALbw3HFL/qeqj4oCY+z1Bp179XpCMGyNhhW12fdozi9UKySNV4BkiULc1U+aMOL8eQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/payload/-/payload-2.5.0.tgz",
+      "integrity": "sha512-OQRpRsQJhrQZ9EKsTCpcL9a9rxpNIEj2CvCDn8QEozx+rD0cUZmOmwIeK5HilXVqvjO9v70kllO5Jtr8QNMjSA==",
       "dev": true,
       "dependencies": {
         "@date-io/date-fns": "2.16.0",

--- a/packages/create-api-docs/package.json
+++ b/packages/create-api-docs/package.json
@@ -12,7 +12,7 @@
     "command-line-args": "^5.2.1",
     "command-line-usage": "^7.0.1",
     "get-tsconfig": "^4.5.0",
-    "payload": "^2.2.0"
+    "payload": "^2.4.0"
   },
   "scripts": {
     "build": "rimraf dist && tsc --sourceMap false",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livit/portal.cms.payload-openapi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Create openapi documentation for your payload cms",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -36,7 +36,7 @@
     "jest": "^29.5.0",
     "lint-staged": "^13.1.2",
     "openapi-types": "^12.1.0",
-    "payload": "^2.2.0",
+    "payload": "^2.4.0",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
     "ts-jest": "^29.1.0",

--- a/packages/openapi/src/schemas/entity-to-schema.ts
+++ b/packages/openapi/src/schemas/entity-to-schema.ts
@@ -29,6 +29,13 @@ const stripEmptyRequired = (schema: OpenAPIV3.SchemaObject): OpenAPIV3.SchemaObj
     };
   }
 
+  // Payload is disabling all the additionalProperties in the schemas by default.
+  // This need to be unset instead of giving `false` value to allow receiver/generator to support
+  // for additional properties to model classes.
+  if (schema.additionalProperties === false) {
+    delete schema.additionalProperties;
+  }
+
   return {
     ...schema,
     properties:

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livit/portal.cms.payload-swagger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Swagger plugin for payload cms",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@livit/portal.cms.payload-openapi": "^1.0.1",
+    "@livit/portal.cms.payload-openapi": "^1.0.2",
     "swagger-ui-express": "^4.6.2"
   },
   "peerDependencies": {
@@ -36,7 +36,7 @@
     "husky": "^8.0.3",
     "jest": "^29.5.0",
     "lint-staged": "^13.1.2",
-    "payload": "^2.2.0",
+    "payload": "^2.4.0",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
     "ts-jest": "^29.1.0",

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -23,7 +23,7 @@ function npmPublish(packageName: string): void {
         execSync(`npm run build -w @livit/portal.cms.payload-openapi`, { stdio: 'inherit' });
         console.log(`Building package ${packageName}`);
         execSync(`npm run build -w ${packageName}`, { stdio: 'inherit' });
-        execSync(`npm publish -w ${packageName}`, { stdio: 'inherit' });
+        execSync(`npm publish -w ${packageName} --access public`, { stdio: 'inherit' });
       }
       break;
   }


### PR DESCRIPTION
Description:
Bumps payload version and unset additionalProperties in payload schemas to allow receiver\generator to support for additional properties to model classes (https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/csharp.md?plain=1#L27).

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
