### PR TITLE
refactor(HPP-00): update paginated document schema and use swagger in…

### DIFF
--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livit/portal.cms.payload-openapi",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Create openapi documentation for your payload cms",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/openapi/src/base-config/index.ts
+++ b/packages/openapi/src/base-config/index.ts
@@ -5,12 +5,14 @@ import { confirmation } from './confirm';
 import where from './where';
 import { Options } from '../options';
 import { createResponse } from '../schemas';
+import { paginatedDocument } from '../schemas/paginated-documents';
 
 export * from './parameters';
 
 const schemas: Record<string, OpenAPIV3.SchemaObject> = {
   errorResponse,
   confirmation,
+  paginatedDocument,
   where,
 };
 

--- a/packages/openapi/src/schemas/paginated-documents.ts
+++ b/packages/openapi/src/schemas/paginated-documents.ts
@@ -1,15 +1,9 @@
 import type { OpenAPIV3 } from 'openapi-types';
 
-export const createPaginatedDocumentSchema = (schemaName: string, title: string): OpenAPIV3.SchemaObject => ({
+export const paginatedDocument: OpenAPIV3.SchemaObject = {
+  title: 'Paginated Document',
   type: 'object',
-  title,
   properties: {
-    docs: {
-      type: 'array',
-      items: {
-        '$ref': `#/components/schemas/${schemaName}`,
-      },
-    },
     totalDocs: { type: 'number' },
     limit: { type: 'number' },
     totalPages: { type: 'number' },
@@ -20,5 +14,27 @@ export const createPaginatedDocumentSchema = (schemaName: string, title: string)
     prevPage: { type: 'number' },
     nextPage: { type: 'number' },
   },
-  required: ['docs', 'totalDocs', 'limit', 'totalPages', 'page', 'pagingCounter', 'hasPrevPage', 'hasNextPage'],
-});
+  required: ['totalDocs', 'limit', 'totalPages', 'page', 'pagingCounter', 'hasPrevPage', 'hasNextPage'],
+};
+
+export const createPaginatedDocumentSchema = (schemaName: string, title: string): OpenAPIV3.SchemaObject => {
+  return {
+    title,
+    allOf: [
+      {
+        properties: {
+          docs: {
+            type: 'array',
+            items: {
+              '$ref': `#/components/schemas/${schemaName}`,
+            },
+          },
+        },
+        required: ['docs'],
+      },
+      {
+        $ref: '#/components/schemas/paginatedDocument',
+      },
+    ],
+  };
+};

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livit/portal.cms.payload-swagger",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Swagger plugin for payload cms",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@livit/portal.cms.payload-openapi": "^1.0.5",
+    "@livit/portal.cms.payload-openapi": "^1.0.6",
     "swagger-ui-express": "^4.6.2"
   },
   "peerDependencies": {

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -14,7 +14,7 @@ function npmPublish(packageName: string): void {
       {
         console.log(`Building package ${packageName}`);
         execSync(`npm run build -w ${packageName}`, { stdio: 'inherit' });
-        execSync(`npm publish -w ${packageName}`, { stdio: 'inherit' });
+        execSync(`npm publish -w ${packageName} --access public`, { stdio: 'inherit' });
       }
       break;
     case '@livit/portal.cms.payload-swagger':


### PR DESCRIPTION
Refactor: Paginated documents creation model

before:
```
      properties:
        docs:
          items:
            $ref: "#/components/schemas/<schemaName>"
          type: array
        totalDocs:
          type: number
        limit:
          type: number
        totalPages:
          type: number
        page:
          type: number
        pagingCounter:
          type: number
        hasPrevPage:
          type: boolean
        hasNextPage:
          type: boolean
        prevPage:
          type: number
        nextPage:
          type: number
      required:
        - docs
        - hasNextPage
        - hasPrevPage
        - limit
        - page
        - pagingCounter
        - totalDocs
        - totalPages
      title: Users
      type: object
```

after:
```
      allOf:
        - $ref: "#/components/schemas/paginatedDocument"
        - properties:
            docs:
              items:
                $ref: "#/components/schemas/<schemaName>"
              type: array
          required:
            - docs
      type: object
```

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
